### PR TITLE
disable dice based on roll

### DIFF
--- a/app/components/Dice.jsx
+++ b/app/components/Dice.jsx
@@ -1,31 +1,47 @@
 import React, {Component} from 'react';
 import {addAction} from '../reducers/action-creators'
-import { newDiceRoll } from '../reducers/dice'; 
-
+import { newDiceRoll } from '../reducers/dice';
+import store from '../store';
 
 export class Dice extends Component {
   constructor(props) {
     super(props);
     this.state = {
-    	d1: 1,
-    	d2: 1
+    	d1: null,
+    	d2: null,
+      diceEnabled: true //this should be true by default
     }
     this.rollDice = this.rollDice.bind(this)
   }
 
-  rollDice() {
+  rollDice(bool) {
   	let d1 = Math.floor(Math.random() * 6) + 1;
     let d2 = Math.floor(Math.random() * 6) + 1;
-    this.setState({d1: d1, d2: d2}); //TODO: disable rollDice after roll unless double (remove isDouble)
-    return {sum: d1+d2, isDouble: d1===d2}; //return the object that will be stored on the state since all the calcs are done in this function
+    if (d1 === d2) { //if the roll is a double, keep the dice enabled to allow for additional rolls
+      this.setState({d1: d1, d2: d2, diceEnabled: true});
+    }
+    else this.setState({d1: d1, d2: d2, diceEnabled: false});
+    return {sum: d1+d2}; //return the object that will be stored on the state since all the calcs are done in this function
   }
 
   render() {
     return (
     	<div>
-		  <img src={`/die/d${this.state.d1}.gif`}/>
-		  <img src={`/die/d${this.state.d2}.gif`}/>
-		  <button onClick={() => addAction(newDiceRoll(this.rollDice()))}>Roll Dice</button>
+      { this.state.d1 && this.state.d2 ?
+        <div>
+           <img src={`/die/d${this.state.d1}.gif`}/>
+           <img src={`/die/d${this.state.d2}.gif`}/>
+         </div>
+       :
+       <div></div>
+      }
+
+      { this.props.players.length > 0 && this.props.loggedInUser.displayName === this.props.players[this.props.turnInfo-1].name && this.state.diceEnabled ?
+
+        <button onClick={() => addAction(newDiceRoll(this.rollDice()))}>Roll Dice</button>
+          :
+          <button disabled>Can't Roll Dice</button>
+      }
       <div>Last roll:{this.props.diceRoll.sum}</div>
 		</div>
 
@@ -37,6 +53,6 @@ export class Dice extends Component {
 
 import {connect} from 'react-redux';
 
-const mapStore = ({ diceRoll }) => ({diceRoll})
+const mapStore = ({ diceRoll, loggedInUser, turnInfo, players }) => ({diceRoll, loggedInUser, turnInfo, players})
 
 export default connect(mapStore, null)(Dice);

--- a/app/components/PlayerStat.js
+++ b/app/components/PlayerStat.js
@@ -11,7 +11,8 @@ import MenuItem from 'material-ui/MenuItem'
 import store from '../store'
 import {addPlayer, incrementResource, decrementResource} from '../reducers/players';
 import {addAction} from '../reducers/action-creators';
-import {startGame} from '../reducers/home'
+import {startGame} from '../reducers/home';
+import {newDiceRoll} from '../reducers/dice';
 //needs to know which player's card is showing
 
 const validate = values => {
@@ -33,7 +34,7 @@ export class PlayerStat extends Component {
   }
 
   changeCount(resource, isGoingUp){
-    isGoingUp? addAction(incrementResource(this.props.loggedInUser.displayName, resource)) : 
+    isGoingUp? addAction(incrementResource(this.props.loggedInUser.displayName, resource)) :
       addAction(decrementResource(this.props.loggedInUser.displayName, resource))
   }
 
@@ -96,7 +97,7 @@ export class PlayerStat extends Component {
     });
     return (
       <div>
-        {resource ? 
+        {resource ?
         <div>
           <div>
             <input type="button" onClick={() => this.changeCount('wool',false) } value="-"/>

--- a/app/reducers/dice.jsx
+++ b/app/reducers/dice.jsx
@@ -9,7 +9,7 @@ export const newDiceRoll = diceRoll => ({ type: DICE_ROLL, diceRoll }) //payload
 
 /* ------------       REDUCER     ------------------ */
                                 //diceRoll is defined one-level deep, but the default could also point to {}
-export default function reducer (diceRoll = {sum: 2, isDouble: false}, action) {
+export default function reducer (diceRoll = {sum: 4}, action) {
   switch (action.type) {
     case DICE_ROLL:
       return action.diceRoll


### PR DESCRIPTION
_if you're the current player, you can roll the dice
_if you roll the dice and it's a double, the Roll Dice button is still enabled
_non-double rolls disable the button
_at the beginning of your turn, no dice are rendered
